### PR TITLE
escape % everywhere except %s

### DIFF
--- a/plugin/yank-code.vim
+++ b/plugin/yank-code.vim
@@ -27,7 +27,7 @@ function! s:go(...) abort
     else
       let line_note = '(lines '.start_line.'-'.end_line.')'
     endif
-    call add(code, printf(&commentstring, @%.' '.line_note))
+    call add(code, printf(substitute(&commentstring, '%\([^s]\)', '%%\1', 'g'), ' ' . @% . ' ' . line_note))
   endif
 
   let max_line_num_len = strlen(end_line)


### PR DESCRIPTION
otherwise, e.g., in LaTeX, the comment marker will be erroneously replaced resulting in an error E767